### PR TITLE
Add link to offical-website

### DIFF
--- a/basic/collision-js.html
+++ b/basic/collision-js.html
@@ -48,7 +48,7 @@
     </nav>
     <div class="container-xl mt-4">
       <div class="alert alert-danger" role="alert">
-        公式サイトのサンプルデモページに統合されました、<a href="https://akashic-games.github.io/demo/collision-js.html">こちら</a>を参照してください。
+        このページは公式サイトのサンプルデモページに統合されました。<a href="https://akashic-games.github.io/demo/collision-js.html">こちら</a>を参照してください。
       </div>
       <div class="markdown-body">
         <h1>collision-js によるヒット判定</h1><p>collision-js は算術ライブラリを含むコリジョンライブラリです。

--- a/basic/collision-js.html
+++ b/basic/collision-js.html
@@ -47,6 +47,9 @@
       </div>
     </nav>
     <div class="container-xl mt-4">
+      <div class="alert alert-danger" role="alert">
+        公式サイトのサンプルデモページに統合されました、<a href="https://akashic-games.github.io/demo/collision-js.html">こちら</a>を参照してください。
+      </div>
       <div class="markdown-body">
         <h1>collision-js によるヒット判定</h1><p>collision-js は算術ライブラリを含むコリジョンライブラリです。
 collision-js を利用すると矩形や円といったシェイプ同士が重なっているかどうかを判定できます。</p>

--- a/basic/oekaki-js.html
+++ b/basic/oekaki-js.html
@@ -48,7 +48,7 @@
     </nav>
     <div class="container-xl mt-4">
       <div class="alert alert-danger" role="alert">
-        公式サイトのサンプルデモページに統合されました、<a href="https://akashic-games.github.io/demo/oekaki.html">こちら</a>を参照してください。
+        このページは公式サイトのサンプルデモページに統合されました。<a href="https://akashic-games.github.io/demo/oekaki.html">こちら</a>を参照してください。
       </div>
       <div class="markdown-body">
         <h1>おえかき (JavaScript)</h1><p>画面内をマウスや指で画面をなぞると線を書けます。</p>

--- a/basic/oekaki-js.html
+++ b/basic/oekaki-js.html
@@ -47,6 +47,9 @@
       </div>
     </nav>
     <div class="container-xl mt-4">
+      <div class="alert alert-danger" role="alert">
+        公式サイトのサンプルデモページに統合されました、<a href="https://akashic-games.github.io/demo/oekaki.html">こちら</a>を参照してください。
+      </div>
       <div class="markdown-body">
         <h1>おえかき (JavaScript)</h1><p>画面内をマウスや指で画面をなぞると線を書けます。</p>
 <div class="embed-responsive embed-responsive-16by9 border mx-auto">

--- a/basic/oekaki-ts.html
+++ b/basic/oekaki-ts.html
@@ -47,6 +47,9 @@
       </div>
     </nav>
     <div class="container-xl mt-4">
+      <div class="alert alert-danger" role="alert">
+        公式サイトのサンプルデモページに統合されました、<a href="https://akashic-games.github.io/demo/oekaki.html">こちら</a>を参照してください。
+      </div>
       <div class="markdown-body">
         <h1>おえかき (TypeScript)</h1><p>画面内をマウスや指で画面をなぞると線を書けます。</p>
 <div class="embed-responsive embed-responsive-16by9 border mx-auto">

--- a/basic/oekaki-ts.html
+++ b/basic/oekaki-ts.html
@@ -48,7 +48,7 @@
     </nav>
     <div class="container-xl mt-4">
       <div class="alert alert-danger" role="alert">
-        公式サイトのサンプルデモページに統合されました、<a href="https://akashic-games.github.io/demo/oekaki.html">こちら</a>を参照してください。
+        このページは公式サイトのサンプルデモページに統合されました。<a href="https://akashic-games.github.io/demo/oekaki.html">こちら</a>を参照してください。
       </div>
       <div class="markdown-body">
         <h1>おえかき (TypeScript)</h1><p>画面内をマウスや指で画面をなぞると線を書けます。</p>

--- a/box2d/drag-throw.html
+++ b/box2d/drag-throw.html
@@ -47,6 +47,9 @@
       </div>
     </nav>
     <div class="container-xl mt-4">
+      <div class="alert alert-danger" role="alert">
+        公式サイトのサンプルデモページに統合されました、<a href="https://akashic-games.github.io/demo/drag-throw.html">こちら</a>を参照してください。
+      </div>
       <div class="markdown-body">
         <h1>ドラッグして飛ばす</h1><p>赤い箱をドラッグすると、ドラッグした座標に追従して赤い箱が動きます。
 ドラッグが解除されたとき、事前のドラッグ操作に合わせて箱を投げることができます。</p>

--- a/box2d/drag-throw.html
+++ b/box2d/drag-throw.html
@@ -48,7 +48,7 @@
     </nav>
     <div class="container-xl mt-4">
       <div class="alert alert-danger" role="alert">
-        公式サイトのサンプルデモページに統合されました、<a href="https://akashic-games.github.io/demo/drag-throw.html">こちら</a>を参照してください。
+        このページは公式サイトのサンプルデモページに統合されました。<a href="https://akashic-games.github.io/demo/drag-throw.html">こちら</a>を参照してください。
       </div>
       <div class="markdown-body">
         <h1>ドラッグして飛ばす</h1><p>赤い箱をドラッグすると、ドラッグした座標に追従して赤い箱が動きます。

--- a/box2d/draw-polygon.html
+++ b/box2d/draw-polygon.html
@@ -47,6 +47,9 @@
       </div>
     </nav>
     <div class="container-xl mt-4">
+      <div class="alert alert-danger" role="alert">
+        公式サイトのサンプルデモページに統合されました、<a href="https://akashic-games.github.io/demo/draw-polygon.html">こちら</a>を参照してください。
+      </div>
       <div class="markdown-body">
         <h1>多角形を描く</h1><p>以下の枠線内をタッチすることで多角形を描画することができ、多角形が閉じられたときに衝突判定も生成されます。
 多角形の頂点は時計回りに指定します。

--- a/box2d/draw-polygon.html
+++ b/box2d/draw-polygon.html
@@ -48,7 +48,7 @@
     </nav>
     <div class="container-xl mt-4">
       <div class="alert alert-danger" role="alert">
-        公式サイトのサンプルデモページに統合されました、<a href="https://akashic-games.github.io/demo/draw-polygon.html">こちら</a>を参照してください。
+        このページは公式サイトのサンプルデモページに統合されました。<a href="https://akashic-games.github.io/demo/draw-polygon.html">こちら</a>を参照してください。
       </div>
       <div class="markdown-body">
         <h1>多角形を描く</h1><p>以下の枠線内をタッチすることで多角形を描画することができ、多角形が閉じられたときに衝突判定も生成されます。

--- a/box2d/hajiki.html
+++ b/box2d/hajiki.html
@@ -48,7 +48,7 @@
     </nav>
     <div class="container-xl mt-4">
       <div class="alert alert-danger" role="alert">
-        公式サイトのサンプルデモページに統合されました、<a href="https://akashic-games.github.io/demo/hajiki.html">こちら</a>を参照してください。
+        このページは公式サイトのサンプルデモページに統合されました。<a href="https://akashic-games.github.io/demo/hajiki.html">こちら</a>を参照してください。
       </div>
       <div class="markdown-body">
         <h1>おはじき</h1><p>見下ろし視点の「おはじき」をイメージしたサンプルです。

--- a/box2d/hajiki.html
+++ b/box2d/hajiki.html
@@ -47,6 +47,9 @@
       </div>
     </nav>
     <div class="container-xl mt-4">
+      <div class="alert alert-danger" role="alert">
+        公式サイトのサンプルデモページに統合されました、<a href="https://akashic-games.github.io/demo/hajiki.html">こちら</a>を参照してください。
+      </div>
       <div class="markdown-body">
         <h1>おはじき</h1><p>見下ろし視点の「おはじき」をイメージしたサンプルです。
 画面上に配置された円形を始点にドラッグすることで、ドラッグ方向とは反対に円を飛ばすことができます。</p>

--- a/box2d/hello-box2d.html
+++ b/box2d/hello-box2d.html
@@ -47,6 +47,9 @@
       </div>
     </nav>
     <div class="container-xl mt-4">
+      <div class="alert alert-danger" role="alert">
+        公式サイトのサンプルデモページに統合されました、<a href="https://akashic-games.github.io/demo/hello-box2d.html">こちら</a>を参照してください。
+      </div>
       <div class="markdown-body">
         <h1>箱を落とす</h1><p>以下の枠線内をタッチすることで、タッチした座標に赤い矩形を生成します。
 生成された矩形は衝突判定と物理挙動を持っていて、重力に従って下へ移動していきます。</p>

--- a/box2d/hello-box2d.html
+++ b/box2d/hello-box2d.html
@@ -48,7 +48,7 @@
     </nav>
     <div class="container-xl mt-4">
       <div class="alert alert-danger" role="alert">
-        公式サイトのサンプルデモページに統合されました、<a href="https://akashic-games.github.io/demo/hello-box2d.html">こちら</a>を参照してください。
+        このページは公式サイトのサンプルデモページに統合されました。<a href="https://akashic-games.github.io/demo/hello-box2d.html">こちら</a>を参照してください。
       </div>
       <div class="markdown-body">
         <h1>箱を落とす</h1><p>以下の枠線内をタッチすることで、タッチした座標に赤い矩形を生成します。

--- a/box2d/hit-break.html
+++ b/box2d/hit-break.html
@@ -48,7 +48,7 @@
     </nav>
     <div class="container-xl mt-4">
       <div class="alert alert-danger" role="alert">
-        公式サイトのサンプルデモページに統合されました、<a href="https://akashic-games.github.io/demo/hit-break.html">こちら</a>を参照してください。
+        このページは公式サイトのサンプルデモページに統合されました。<a href="https://akashic-games.github.io/demo/hit-break.html">こちら</a>を参照してください。
       </div>
       <div class="markdown-body">
         <h1>ぶつかると散る</h1><p>以下の枠線内でタッチされた場所の下部より、赤い箱が上に打ち出されます。

--- a/box2d/hit-break.html
+++ b/box2d/hit-break.html
@@ -47,6 +47,9 @@
       </div>
     </nav>
     <div class="container-xl mt-4">
+      <div class="alert alert-danger" role="alert">
+        公式サイトのサンプルデモページに統合されました、<a href="https://akashic-games.github.io/demo/hit-break.html">こちら</a>を参照してください。
+      </div>
       <div class="markdown-body">
         <h1>ぶつかると散る</h1><p>以下の枠線内でタッチされた場所の下部より、赤い箱が上に打ち出されます。
 箱同士が衝突すると、斜め 4 方向へ箱が分裂して飛び散ります。

--- a/box2d/machine-gun.html
+++ b/box2d/machine-gun.html
@@ -48,7 +48,7 @@
     </nav>
     <div class="container-xl mt-4">
       <div class="alert alert-danger" role="alert">
-        公式サイトのサンプルデモページに統合されました、<a href="https://akashic-games.github.io/demo/machine-gun.html">こちら</a>を参照してください。
+        このページは公式サイトのサンプルデモページに統合されました。<a href="https://akashic-games.github.io/demo/machine-gun.html">こちら</a>を参照してください。
       </div>
       <div class="markdown-body">
         <h1>マシンガン</h1><p>以下の枠線内のタッチされた座標から銃弾が発射されます。

--- a/box2d/machine-gun.html
+++ b/box2d/machine-gun.html
@@ -47,6 +47,9 @@
       </div>
     </nav>
     <div class="container-xl mt-4">
+      <div class="alert alert-danger" role="alert">
+        公式サイトのサンプルデモページに統合されました、<a href="https://akashic-games.github.io/demo/machine-gun.html">こちら</a>を参照してください。
+      </div>
       <div class="markdown-body">
         <h1>マシンガン</h1><p>以下の枠線内のタッチされた座標から銃弾が発射されます。
 画面左側をタッチしていると右側に赤い銃弾が、右側をタッチしていると左側に緑色の銃弾が発射されます。

--- a/box2d/newtons-cradle.html
+++ b/box2d/newtons-cradle.html
@@ -47,6 +47,9 @@
       </div>
     </nav>
     <div class="container-xl mt-4">
+      <div class="alert alert-danger" role="alert">
+        公式サイトのサンプルデモページに統合されました、<a href="https://akashic-games.github.io/demo/newtons-cradle.html">こちら</a>を参照してください。
+      </div>
       <div class="markdown-body">
         <h1>ニュートンのゆりかご</h1><p>「ニュートンのゆりかご」のシミュレートです。
 ボールは上部の空間に紐で固定されていて、固定位置を中心にドラッグで移動することができます。</p>

--- a/box2d/newtons-cradle.html
+++ b/box2d/newtons-cradle.html
@@ -48,7 +48,7 @@
     </nav>
     <div class="container-xl mt-4">
       <div class="alert alert-danger" role="alert">
-        公式サイトのサンプルデモページに統合されました、<a href="https://akashic-games.github.io/demo/newtons-cradle.html">こちら</a>を参照してください。
+        このページは公式サイトのサンプルデモページに統合されました。<a href="https://akashic-games.github.io/demo/newtons-cradle.html">こちら</a>を参照してください。
       </div>
       <div class="markdown-body">
         <h1>ニュートンのゆりかご</h1><p>「ニュートンのゆりかご」のシミュレートです。

--- a/box2d/spring.html
+++ b/box2d/spring.html
@@ -48,7 +48,7 @@
     </nav>
     <div class="container-xl mt-4">
       <div class="alert alert-danger" role="alert">
-        公式サイトのサンプルデモページに統合されました、<a href="https://akashic-games.github.io/demo/spring.html">こちら</a>を参照してください。
+        このページは公式サイトのサンプルデモページに統合されました。<a href="https://akashic-games.github.io/demo/spring.html">こちら</a>を参照してください。
       </div>
       <div class="markdown-body">
         <h1>バネ</h1><p>赤い箱をドラッグすると、ドラッグした座標に追従して赤い箱が動きます。

--- a/box2d/spring.html
+++ b/box2d/spring.html
@@ -47,6 +47,9 @@
       </div>
     </nav>
     <div class="container-xl mt-4">
+      <div class="alert alert-danger" role="alert">
+        公式サイトのサンプルデモページに統合されました、<a href="https://akashic-games.github.io/demo/spring.html">こちら</a>を参照してください。
+      </div>
       <div class="markdown-body">
         <h1>バネ</h1><p>赤い箱をドラッグすると、ドラッグした座標に追従して赤い箱が動きます。
 ドラッグが解除されたとき、事前のドラッグ操作に合わせて箱を投げることができます。

--- a/game/hopping-witch.html
+++ b/game/hopping-witch.html
@@ -48,7 +48,7 @@
     </nav>
     <div class="container-xl mt-4">
       <div class="alert alert-danger" role="alert">
-        公式サイトのサンプルデモページに統合されました、<a href="https://akashic-games.github.io/demo/HoppingWitch.html">こちら</a>を参照してください。
+        このページは公式サイトのサンプルデモページに統合されました。<a href="https://akashic-games.github.io/demo/HoppingWitch.html">こちら</a>を参照してください。
       </div>
       <div class="markdown-body">
         <h1>HOPPING WITCH</h1><p>Akashic エンジンで作成したフラッピーバードクローンです。</p>

--- a/game/hopping-witch.html
+++ b/game/hopping-witch.html
@@ -47,6 +47,9 @@
       </div>
     </nav>
     <div class="container-xl mt-4">
+      <div class="alert alert-danger" role="alert">
+        公式サイトのサンプルデモページに統合されました、<a href="https://akashic-games.github.io/demo/HoppingWitch.html">こちら</a>を参照してください。
+      </div>
       <div class="markdown-body">
         <h1>HOPPING WITCH</h1><p>Akashic エンジンで作成したフラッピーバードクローンです。</p>
 <div class="embed-responsive embed-responsive-16by9 border mx-auto">

--- a/game/software-keyboard.html
+++ b/game/software-keyboard.html
@@ -48,7 +48,7 @@
     </nav>
     <div class="container-xl mt-4">
       <div class="alert alert-danger" role="alert">
-        公式サイトのサンプルデモページに統合されました、<a href="https://akashic-games.github.io/demo/software-keyboard-sample.html">こちら</a>を参照してください。
+        このページは公式サイトのサンプルデモページに統合されました。<a href="https://akashic-games.github.io/demo/software-keyboard-sample.html">こちら</a>を参照してください。
       </div>
       <div class="markdown-body">
         <h1>ソフトウェアキーボード</h1><p>放送画面にキーボードを出すプログラムです。

--- a/game/software-keyboard.html
+++ b/game/software-keyboard.html
@@ -47,6 +47,9 @@
       </div>
     </nav>
     <div class="container-xl mt-4">
+      <div class="alert alert-danger" role="alert">
+        公式サイトのサンプルデモページに統合されました、<a href="https://akashic-games.github.io/demo/software-keyboard-sample.html">こちら</a>を参照してください。
+      </div>
       <div class="markdown-body">
         <h1>ソフトウェアキーボード</h1><p>放送画面にキーボードを出すプログラムです。
 ゲームに組み込むことで文字を入力できるようになります。</p>

--- a/game/tsurikkuma-style-game-js.html
+++ b/game/tsurikkuma-style-game-js.html
@@ -47,6 +47,9 @@
       </div>
     </nav>
     <div class="container-xl mt-4">
+      <div class="alert alert-danger" role="alert">
+        公式サイトのサンプルデモページに統合されました、<a href="https://akashic-games.github.io/demo/tsurikkuma-style-game.html">こちら</a>を参照してください。
+      </div>
       <div class="markdown-body">
         <h1>つりっくま風ゲーム (JavaScript)</h1><p>画面をタップして魚を釣りましょう。改造するとオリジナルのゲームが作れます。</p>
 <div class="embed-responsive embed-responsive-16by9 border mx-auto">

--- a/game/tsurikkuma-style-game-js.html
+++ b/game/tsurikkuma-style-game-js.html
@@ -48,7 +48,7 @@
     </nav>
     <div class="container-xl mt-4">
       <div class="alert alert-danger" role="alert">
-        公式サイトのサンプルデモページに統合されました、<a href="https://akashic-games.github.io/demo/tsurikkuma-style-game.html">こちら</a>を参照してください。
+        このページは公式サイトのサンプルデモページに統合されました。<a href="https://akashic-games.github.io/demo/tsurikkuma-style-game.html">こちら</a>を参照してください。
       </div>
       <div class="markdown-body">
         <h1>つりっくま風ゲーム (JavaScript)</h1><p>画面をタップして魚を釣りましょう。改造するとオリジナルのゲームが作れます。</p>

--- a/game/tsurikkuma-style-game-ts.html
+++ b/game/tsurikkuma-style-game-ts.html
@@ -48,7 +48,7 @@
     </nav>
     <div class="container-xl mt-4">
         <div class="alert alert-danger" role="alert">
-            公式サイトのサンプルデモページに統合されました、<a href="https://akashic-games.github.io/demo/tsurikkuma-style-game.html">こちら</a>を参照してください。
+            このページは公式サイトのサンプルデモページに統合されました。<a href="https://akashic-games.github.io/demo/tsurikkuma-style-game.html">こちら</a>を参照してください。
         </div>
       <div class="markdown-body">
         <h1>つりっくま風ゲーム (TypeScript)</h1><p>画面をタップして魚を釣りましょう。改造するとオリジナルのゲームが作れます。</p>

--- a/game/tsurikkuma-style-game-ts.html
+++ b/game/tsurikkuma-style-game-ts.html
@@ -47,6 +47,9 @@
       </div>
     </nav>
     <div class="container-xl mt-4">
+        <div class="alert alert-danger" role="alert">
+            公式サイトのサンプルデモページに統合されました、<a href="https://akashic-games.github.io/demo/tsurikkuma-style-game.html">こちら</a>を参照してください。
+        </div>
       <div class="markdown-body">
         <h1>つりっくま風ゲーム (TypeScript)</h1><p>画面をタップして魚を釣りましょう。改造するとオリジナルのゲームが作れます。</p>
 <div class="embed-responsive embed-responsive-16by9 border mx-auto">


### PR DESCRIPTION
## 概要

サンプルカタログで公式サイトのデモページとコンテンツが同じものは、ページ上部に公式サイトへの誘導リンクを追加します。

下記スクリーンショットの上部の赤い背景部分が追加箇所です。

<img width="1383" alt="screenshot" src="https://github.com/user-attachments/assets/8cbada97-a606-4dec-8ea0-270480e0abce" />

